### PR TITLE
perf(git): increase git performance and new stuff

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -60,6 +61,17 @@ func Commit(message string) error {
 
 	return nil
 }
+
+func IsInsideWorkTree() error {
+	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+
+	if err := cmd.Run(); err != nil {
+		return errors.New("not inside a git repository")
+	}
+	
+	return nil
+}
+
 
 // Push pushes the changes to the specified branch on origin.
 func Push(branch string) error {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -31,15 +31,15 @@ func StageFiles(files []string) error {
 }
 
 
-// GetStagedDiff returns the diff of staged changes.
 func GetStagedDiff() (string, error) {
 	var diffOutput bytes.Buffer
 	cmd := exec.Command("git", "diff", "--staged")
+
 	cmd.Stdout = &diffOutput
 	cmd.Stderr = &diffOutput
 
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to get git diff: %s", diffOutput.String())
+	return "", fmt.Errorf("git diff --staged failed: %w\n%s", err, diffOutput.String())
 	}
 	return diffOutput.String(), nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -44,15 +44,20 @@ func GetStagedDiff() (string, error) {
 	return diffOutput.String(), nil
 }
 
-// Commit performs a git commit with the given message.
 func Commit(message string) error {
 	var output bytes.Buffer
-	cmd := exec.Command("git", "commit", "-m", message)
+
+	cmd := exec.Command("git", "commit", "-F", "-")
+
+	cmd.Stdin = strings.NewReader(message)
+
 	cmd.Stdout = &output
 	cmd.Stderr = &output
+
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error while committing: %s", output.String())
 	}
+
 	return nil
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -8,18 +8,28 @@ import (
 	"strings"
 )
 
-// StageFiles stages the specified files.
 func StageFiles(files []string) error {
-	for _, file := range files {
-		cmd := exec.Command("git", "add", file)
-		cmd.Stdout = io.Discard
-		cmd.Stderr = io.Discard
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to stage file %s: %v", file, err)
-		}
+	if len(files) == 0 {
+		return nil
 	}
+
+	args := append([]string{"add"}, files...)
+	
+	cmd := exec.Command("git", args...)
+
+	cmd.Stdout = io.Discard
+
+	var stderr bytes.Buffer
+
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git add failed: %s", stderr.String())
+	}
+
 	return nil
 }
+
 
 // GetStagedDiff returns the diff of staged changes.
 func GetStagedDiff() (string, error) {


### PR DESCRIPTION
- Usa `git add <...files>` ao invés de fazer um for/range adicionando um por um (https://github.com/albuquerquesz/gitscribe/commit/8cfd9b2a0da11a25f20d2663474dfc732e7ea18c)
- Expõe o erro corretamente quando ocorre algum erro na função GetStagedDiff (https://github.com/albuquerquesz/gitscribe/commit/3ca12fb4f2e6910f02245e47b510c47460173351)
- Substitui o uso de `-m` para adicionar suporte para `-F` (Usar o stdin), isso evita que a mensagem de commit venha incorreta, com má formatação (https://github.com/albuquerquesz/gitscribe/commit/392381c0c56447ceb0366a5cb421669e71057a44)
- Adiciona a função `IsInsideWorkTree` para melhorar a UX/DX futuramente (https://github.com/albuquerquesz/gitscribe/commit/6a31448b4c86e4fb168be53ced3fd00ecb7779aa)